### PR TITLE
Fix: images not rendering in HTML template PDF output + CSS layout fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -705,7 +705,7 @@ class WhatsAppChatToPDF:
                     msg_html = re.sub(r'\{\{#if this\.show_date\}\}.*?\{\{/if\}\}', '', msg_html, flags=re.DOTALL)
             else:
                 # Regular message
-                msg_html = re.sub(r'\{\{#if this\.is_system\}\}.*?\{\{else\}\}(.*?)\{\{/if\}\}', r'\1', msg_html, flags=re.DOTALL)
+                msg_html = re.sub(r'\{\{#if this\.is_system\}\}.*?\{\{else\}\}(.*)\{\{/if\}\}', r'\1', msg_html, flags=re.DOTALL)
                 
                 # Handle {{#unless this.is_system}} blocks (remove them for non-system messages)
                 msg_html = re.sub(r'\{\{#unless this\.is_system\}\}(.*?)\{\{/unless\}\}', r'\1', msg_html, flags=re.DOTALL)

--- a/templates/template.html
+++ b/templates/template.html
@@ -95,32 +95,32 @@
         }
         
         .message-wrapper {
-    display: block;
-    margin-bottom: 8px;
-    clear: both;
-    overflow: hidden;
-    width: 100%;
-}
+            display: block;
+            margin-bottom: 8px;
+            clear: both;
+            overflow: hidden;
+            width: 100%;
+        }
         
         .message-wrapper.user {
-    text-align: right;
-}
+            text-align: right;
+        }
         
         .message-wrapper.other {
-    text-align: left;
-}
+            text-align: left;
+        }
         
         .message-bubble {
-    max-width: 65%;
-    position: relative;
-    padding: 6px 7px 8px 9px;
-    border-radius: 7.5px;
-    box-shadow: 0 1px 0.5px rgba(0,0,0,0.13);
-    word-wrap: break-word;
-    display: inline-block;
-    text-align: left;
-    overflow: hidden;
-}
+            max-width: 65%;
+            position: relative;
+            padding: 6px 7px 8px 9px;
+            border-radius: 7.5px;
+            box-shadow: 0 1px 0.5px rgba(0,0,0,0.13);
+            word-wrap: break-word;
+            display: inline-block;
+            text-align: left;
+            overflow: hidden;
+        }
         
         .message-wrapper.user .message-bubble {
             background: #d9fdd3;
@@ -157,8 +157,8 @@
         }
         
         .message-wrapper.system {
-    text-align: center;
-}
+            text-align: center;
+        }
         
         .message-wrapper.system .message-bubble {
             background: #e1f3fb;
@@ -235,18 +235,18 @@
         }
         
         .media-wrapper {
-    margin-top: 5px;
-    max-width: 100%;
-    overflow: hidden;
-}
+            margin-top: 5px;
+            max-width: 100%;
+            overflow: hidden;
+        }
         
         .media-wrapper img {
-    max-width: 100%;
-    max-height: 250px;
-    border-radius: 5px;
-    display: block;
-    object-fit: contain;
-}
+            max-width: 100%;
+            max-height: 250px;
+            border-radius: 5px;
+            display: block;
+            object-fit: contain;
+        }
         
         .media-file {
             background: rgba(0,0,0,0.05);

--- a/templates/template.html
+++ b/templates/template.html
@@ -95,27 +95,32 @@
         }
         
         .message-wrapper {
-            display: flex;
-            margin-bottom: 8px;
-            clear: both;
-        }
+    display: block;
+    margin-bottom: 8px;
+    clear: both;
+    overflow: hidden;
+    width: 100%;
+}
         
         .message-wrapper.user {
-            justify-content: flex-end;
-        }
+    text-align: right;
+}
         
         .message-wrapper.other {
-            justify-content: flex-start;
-        }
+    text-align: left;
+}
         
         .message-bubble {
-            max-width: 65%;
-            position: relative;
-            padding: 6px 7px 8px 9px;
-            border-radius: 7.5px;
-            box-shadow: 0 1px 0.5px rgba(0,0,0,0.13);
-            word-wrap: break-word;
-        }
+    max-width: 65%;
+    position: relative;
+    padding: 6px 7px 8px 9px;
+    border-radius: 7.5px;
+    box-shadow: 0 1px 0.5px rgba(0,0,0,0.13);
+    word-wrap: break-word;
+    display: inline-block;
+    text-align: left;
+    overflow: hidden;
+}
         
         .message-wrapper.user .message-bubble {
             background: #d9fdd3;
@@ -152,8 +157,8 @@
         }
         
         .message-wrapper.system {
-            justify-content: center;
-        }
+    text-align: center;
+}
         
         .message-wrapper.system .message-bubble {
             background: #e1f3fb;
@@ -230,15 +235,18 @@
         }
         
         .media-wrapper {
-            margin-top: 5px;
-            max-width: 100%;
-        }
+    margin-top: 5px;
+    max-width: 100%;
+    overflow: hidden;
+}
         
         .media-wrapper img {
-            max-width: 100%;
-            border-radius: 5px;
-            display: block;
-        }
+    max-width: 100%;
+    max-height: 250px;
+    border-radius: 5px;
+    display: block;
+    object-fit: contain;
+}
         
         .media-file {
             background: rgba(0,0,0,0.05);


### PR DESCRIPTION
## Description
Fixed two related bugs with image rendering in PDF output when using HTML templates:

1. **Images not rendering at all:** Only "file attached" text was shown instead of actual embedded images. The root cause was a non-greedy regex `(.*?)` on line 708 of `main.py` that matched to the first `{{/if}}` instead of the last one, destroying the media section HTML during template processing.

2. **CSS layout broken with images:** Once images rendered, WeasyPrint's handling of flexbox caused messages with images to overlap adjacent messages and lose their background styling. Changed layout from flexbox to block/inline-block positioning.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🌍 Translation (new or updated language file)
- [x] 🎨 Template (new or updated HTML template)
- [ ] ♻️ Code refactoring
- [ ] 🎭 Style/formatting changes

## Related Issue
Fixes #1

## Testing

- [x] Tested with sample WhatsApp export
- [ ] Tested on multiple platforms (specify which)
- [ ] Tested with different languages
- [x] Tested with different media types

**Test environment:**
- OS: Windows 11
- Python version: 3.12.2
- WhatsApp export language: English

## Screenshots
No screenshots provided.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
This PR contains two related fixes:

1. **Regex fix (main.py line 708):** Removed `?` from `(.*?)` to make it `(.*)`, changing from non-greedy to greedy matching. This ensures all nested `{{/if}}` blocks are preserved and images actually render.

2. **CSS layout fix (templates/template.html):** Changed message layout from flexbox to block/inline-block positioning. WeasyPrint doesn't handle flexbox well with large embedded images, causing messages to overlap and lose their background styling. Also added max-height constraint on images and overflow handling.

AI was used to help debug and identify the root cause of this issue. This is also my first ever pull request. Woo!